### PR TITLE
Fix auth registration for client credentials

### DIFF
--- a/src/mcp/server/auth/handlers/register.py
+++ b/src/mcp/server/auth/handlers/register.py
@@ -74,12 +74,20 @@ class RegistrationHandler:
                     ),
                     status_code=400,
                 )
-        if set(client_metadata.grant_types) != {"authorization_code", "refresh_token"}:
+        grant_types_set = set(client_metadata.grant_types)
+        valid_sets = [
+            {"authorization_code", "refresh_token"},
+            {"client_credentials"},
+        ]
+
+        if grant_types_set not in valid_sets:
             return PydanticJSONResponse(
                 content=RegistrationErrorResponse(
                     error="invalid_client_metadata",
-                    error_description="grant_types must be authorization_code "
-                    "and refresh_token",
+                    error_description=(
+                        "grant_types must be authorization_code and refresh_token "
+                        "or client_credentials"
+                    ),
                 ),
                 status_code=400,
             )

--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -1001,8 +1001,30 @@ class TestAuthEndpoints:
         assert error_data["error"] == "invalid_client_metadata"
         assert (
             error_data["error_description"]
-            == "grant_types must be authorization_code and refresh_token"
+            == (
+                "grant_types must be authorization_code and "
+                "refresh_token or client_credentials"
+            )
         )
+
+    @pytest.mark.anyio
+    async def test_client_registration_client_credentials(
+        self, test_client: httpx.AsyncClient
+    ):
+        client_metadata = {
+            "redirect_uris": ["https://client.example.com/callback"],
+            "client_name": "CC Client",
+            "grant_types": ["client_credentials"],
+        }
+
+        response = await test_client.post(
+            "/register",
+            json=client_metadata,
+        )
+
+        assert response.status_code == 201, response.content
+        client_info = response.json()
+        assert client_info["grant_types"] == ["client_credentials"]
 
 
 class TestAuthorizeEndpointErrors:


### PR DESCRIPTION
## Summary
- allow client credential grant in dynamic registration
- test registering a client with client credentials
- update invalid grant type test

## Testing
- `ruff check tests/server/fastmcp/auth/test_auth_integration.py`
- `pytest tests/server/fastmcp/auth/test_auth_integration.py::TestAuthEndpoints::test_client_registration_client_credentials tests/server/fastmcp/auth/test_auth_integration.py::TestAuthEndpoints::test_client_registration_invalid_grant_type -q -n0`

------
https://chatgpt.com/codex/tasks/task_e_683f83a7742c8332aeb182e13e04375c