### PR TITLE
Fix resumption token update logic

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -161,8 +161,14 @@ class StreamableHTTPTransport:
                 session_message = SessionMessage(message)
                 await read_stream_writer.send(session_message)
 
-                # Call resumption token callback if we have an ID
-                if sse.id and resumption_callback:
+                # Call resumption token callback if we have an ID. Only update
+                # the resumption token on notifications to avoid overwriting it
+                # with the token from the final response.
+                if (
+                    sse.id
+                    and resumption_callback
+                    and not isinstance(message.root, JSONRPCResponse | JSONRPCError)
+                ):
                     await resumption_callback(sse.id)
 
                 # If this is a response or error return True indicating completion


### PR DESCRIPTION
## Summary
- avoid overwriting resumption token with final response id

## Testing
- `pytest -n 1 tests/shared/test_streamable_http.py::test_streamablehttp_client_resumption -vv -q`


------
https://chatgpt.com/codex/tasks/task_e_683faf63136083328b70f671ee0aca0c