### PR TITLE
Add OAuth token exchange support

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,7 +814,11 @@ async def main():
 The SDK includes [authorization support](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) for connecting to protected MCP servers:
 
 ```python
-from mcp.client.auth import OAuthClientProvider, TokenStorage
+from mcp.client.auth import (
+    OAuthClientProvider,
+    TokenExchangeProvider,
+    TokenStorage,
+)
 from mcp.client.session import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
@@ -853,6 +857,20 @@ async def main():
 
     # For machine-to-machine scenarios, use ClientCredentialsProvider
     # instead of OAuthClientProvider.
+
+    # If you already have a user token from another provider,
+    # you can exchange it for an MCP token using TokenExchangeProvider.
+    token_exchange_auth = TokenExchangeProvider(
+        server_url="https://api.example.com",
+        client_metadata=OAuthClientMetadata(
+            client_name="My Client",
+            redirect_uris=["http://localhost:3000/callback"],
+            grant_types=["urn:ietf:params:oauth:grant-type:token-exchange"],
+            response_types=["code"],
+        ),
+        storage=CustomTokenStorage(),
+        subject_token_supplier=lambda: "user_token",
+    )
 
     # Use with streamable HTTP client
     async with streamablehttp_client(

--- a/src/mcp/server/auth/handlers/register.py
+++ b/src/mcp/server/auth/handlers/register.py
@@ -78,6 +78,7 @@ class RegistrationHandler:
         valid_sets = [
             {"authorization_code", "refresh_token"},
             {"client_credentials"},
+            {"urn:ietf:params:oauth:grant-type:token-exchange"},
         ]
 
         if grant_types_set not in valid_sets:
@@ -86,7 +87,7 @@ class RegistrationHandler:
                     error="invalid_client_metadata",
                     error_description=(
                         "grant_types must be authorization_code and refresh_token "
-                        "or client_credentials"
+                        "or client_credentials or token exchange"
                     ),
                 ),
                 status_code=400,

--- a/src/mcp/server/auth/provider.py
+++ b/src/mcp/server/auth/provider.py
@@ -80,6 +80,7 @@ TokenErrorCode = Literal[
     "unauthorized_client",
     "unsupported_grant_type",
     "invalid_scope",
+    "invalid_target",
 ]
 
 
@@ -251,6 +252,20 @@ class OAuthAuthorizationServerProvider(
         self, client: OAuthClientInformationFull, scopes: list[str]
     ) -> OAuthToken:
         """Exchange client credentials for an access token."""
+        ...
+
+    async def exchange_token(
+        self,
+        client: OAuthClientInformationFull,
+        subject_token: str,
+        subject_token_type: str,
+        actor_token: str | None,
+        actor_token_type: str | None,
+        scope: list[str] | None,
+        audience: str | None,
+        resource: str | None,
+    ) -> OAuthToken:
+        """Exchange an external token for an MCP access token."""
         ...
 
     async def load_access_token(self, token: str) -> AccessTokenT | None:

--- a/src/mcp/server/auth/routes.py
+++ b/src/mcp/server/auth/routes.py
@@ -168,6 +168,7 @@ def build_metadata(
             "authorization_code",
             "refresh_token",
             "client_credentials",
+            "urn:ietf:params:oauth:grant-type:token-exchange",
         ],
         token_endpoint_auth_methods_supported=["client_secret_post"],
         token_endpoint_auth_signing_alg_values_supported=None,

--- a/src/mcp/shared/auth.py
+++ b/src/mcp/shared/auth.py
@@ -13,6 +13,7 @@ class OAuthToken(BaseModel):
     expires_in: int | None = None
     scope: str | None = None
     refresh_token: str | None = None
+    issued_token_type: str | None = None
 
 
 class InvalidScopeError(Exception):
@@ -41,7 +42,12 @@ class OAuthClientMetadata(BaseModel):
     )
     # grant_types: support authorization_code, refresh_token, client_credentials
     grant_types: list[
-        Literal["authorization_code", "refresh_token", "client_credentials"]
+        Literal[
+            "authorization_code",
+            "refresh_token",
+            "client_credentials",
+            "urn:ietf:params:oauth:grant-type:token-exchange",
+        ]
     ] = [
         "authorization_code",
         "refresh_token",
@@ -121,6 +127,7 @@ class OAuthMetadata(BaseModel):
                 "authorization_code",
                 "refresh_token",
                 "client_credentials",
+                "urn:ietf:params:oauth:grant-type:token-exchange",
             ]
         ]
         | None


### PR DESCRIPTION
## Summary
- support RFC 8693 token exchange in OAuth handler and metadata
- implement exchange_token provider hook and client TokenExchangeProvider
- extend OAuth models for token exchange grant type
- update registration and tests for token exchange
- document token exchange usage in README

## Testing
- `pre-commit run --files README.md src/mcp/client/auth.py src/mcp/server/auth/handlers/register.py src/mcp/server/auth/handlers/token.py src/mcp/server/auth/provider.py src/mcp/server/auth/routes.py src/mcp/shared/auth.py tests/client/test_auth.py tests/server/fastmcp/auth/test_auth_integration.py` *(fails: pyright errors)*
- `pytest` *(fails: many errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848a98de1d88332be12bf87df6a25f0