### PR TITLE
Add token exchange docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,8 +858,9 @@ async def main():
     # For machine-to-machine scenarios, use ClientCredentialsProvider
     # instead of OAuthClientProvider.
 
-    # If you already have a user token from another provider,
-    # you can exchange it for an MCP token using TokenExchangeProvider.
+    # If you already have a user token from another provider, you can
+    # exchange it for an MCP token using the token-exchange grant
+    # implemented by TokenExchangeProvider.
     token_exchange_auth = TokenExchangeProvider(
         server_url="https://api.example.com",
         client_metadata=OAuthClientMetadata(

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,1 +1,5 @@
+The Python SDK exposes the entire `mcp` package for use in your own projects.
+It includes an OAuth server implementation with support for the RFC 8693
+`token-exchange` grant type.
+
 ::: mcp

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,7 @@
 This is the MCP Server implementation in Python.
 
 It only contains the [API Reference](api.md) for the time being.
+
+The built-in OAuth server supports the RFC 8693 `token-exchange` grant type,
+allowing clients to exchange user tokens from external providers for MCP
+access tokens.


### PR DESCRIPTION
## Summary
- document token exchange grant type in docs and README

## Testing
- `pytest -p no:xdist -c /tmp/pytest.ini tests/server/fastmcp/auth/test_auth_integration.py -k token_exchange -q`

------
https://chatgpt.com/codex/tasks/task_e_6848af6670fc8332af8cadc147f7d5c5