### PR TITLE
Fix token exchange metadata tests

### DIFF
--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -11,7 +11,7 @@ from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
-from pydantic import AnyHttpUrl
+from pydantic import AnyHttpUrl, AnyUrl
 
 from mcp.client.auth import (
     ClientCredentialsProvider,
@@ -91,6 +91,7 @@ def oauth_metadata():
             "authorization_code",
             "refresh_token",
             "client_credentials",
+            "token-exchange",
         ],
         code_challenge_methods_supported=["S256"],
     )
@@ -1014,6 +1015,7 @@ def test_build_metadata(
             "authorization_code",
             "refresh_token",
             "client_credentials",
+            "token-exchange",
         ],
         token_endpoint_auth_methods_supported=["client_secret_post"],
         service_documentation=AnyHttpUrl(service_documentation_url),

--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -417,6 +417,7 @@ class TestAuthEndpoints:
             "authorization_code",
             "refresh_token",
             "client_credentials",
+            "token-exchange",
         ]
         assert metadata["service_documentation"] == "https://docs.example.com/"
 
@@ -1030,7 +1031,7 @@ class TestAuthEndpoints:
         assert error_data["error"] == "invalid_client_metadata"
         assert error_data["error_description"] == (
             "grant_types must be authorization_code and "
-            "refresh_token or client_credentials"
+            "refresh_token or client_credentials or token exchange"
         )
 
     @pytest.mark.anyio
@@ -1361,10 +1362,7 @@ class TestAuthorizeEndpointErrors:
         response = await test_client.get("/.well-known/oauth-authorization-server")
         assert response.status_code == 200
         metadata = response.json()
-        assert (
-            "token-exchange"
-            in metadata["grant_types_supported"]
-        )
+        assert "token-exchange" in metadata["grant_types_supported"]
 
     @pytest.mark.anyio
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- update expected grant types to include token-exchange
- update invalid grant type test message

## Testing
- `uv run --frozen ruff format tests/client/test_auth.py tests/server/fastmcp/auth/test_auth_integration.py`
- `uv run --frozen ruff check tests/client/test_auth.py tests/server/fastmcp/auth/test_auth_integration.py`
- `uv run --frozen pyright src`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD="" uv run --frozen pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b3df77c48332ba5f809f8ba01330