### PR TITLE
Fix pyright case issues in tests and example

### DIFF
--- a/examples/servers/simple-auth/mcp_simple_auth/server.py
+++ b/examples/servers/simple-auth/mcp_simple_auth/server.py
@@ -247,6 +247,20 @@ class SimpleGitHubOAuthProvider(OAuthAuthorizationServerProvider):
         """Exchange refresh token"""
         raise NotImplementedError("Not supported")
 
+    async def exchange_token(
+        self,
+        client: OAuthClientInformationFull,
+        subject_token: str,
+        subject_token_type: str,
+        actor_token: str | None,
+        actor_token_type: str | None,
+        scope: list[str] | None,
+        audience: str | None,
+        resource: str | None,
+    ) -> OAuthToken:
+        """Exchange an external token for an MCP access token."""
+        raise NotImplementedError("Token exchange is not supported")
+
     async def exchange_client_credentials(
         self, client: OAuthClientInformationFull, scopes: list[str]
     ) -> OAuthToken:
@@ -260,7 +274,7 @@ class SimpleGitHubOAuthProvider(OAuthAuthorizationServerProvider):
         )
         return OAuthToken(
             access_token=token,
-            token_type="bearer",
+            token_type="Bearer",
             expires_in=3600,
             scope=" ".join(scopes),
         )

--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -179,7 +179,7 @@ class MockOAuthProvider(OAuthAuthorizationServerProvider):
         )
         return OAuthToken(
             access_token=access_token,
-            token_type="bearer",
+            token_type="Bearer",
             expires_in=3600,
             scope=" ".join(scopes),
         )
@@ -207,7 +207,7 @@ class MockOAuthProvider(OAuthAuthorizationServerProvider):
         )
         return OAuthToken(
             access_token=access_token,
-            token_type="bearer",
+            token_type="Bearer",
             expires_in=3600,
             scope=" ".join(scope or ["read"]),
         )


### PR DESCRIPTION
## Summary
- fix token_type case in tests and simple auth example
- implement missing method in `SimpleGitHubOAuthProvider`

## Testing
- `uv run --frozen ruff check examples/servers/simple-auth/mcp_simple_auth/server.py tests/server/fastmcp/auth/test_auth_integration.py`
- `uv run --frozen pyright`
- `uv run --frozen pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848b783ec6083329c33e5bc4600e7b2