### PR TITLE
Fix resumption token whitespace handling

### DIFF
--- a/src/mcp/client/streamable_http.py
+++ b/src/mcp/client/streamable_http.py
@@ -169,7 +169,7 @@ class StreamableHTTPTransport:
                     and resumption_callback
                     and not isinstance(message.root, JSONRPCResponse | JSONRPCError)
                 ):
-                    await resumption_callback(sse.id)
+                    await resumption_callback(sse.id.strip())
 
                 # If this is a response or error return True indicating completion
                 # Otherwise, return False to continue listening
@@ -218,7 +218,7 @@ class StreamableHTTPTransport:
         """Handle a resumption request using GET with SSE."""
         headers = self._update_headers_with_session(ctx.headers)
         if ctx.metadata and ctx.metadata.resumption_token:
-            headers[LAST_EVENT_ID] = ctx.metadata.resumption_token
+            headers[LAST_EVENT_ID] = ctx.metadata.resumption_token.strip()
         else:
             raise ResumptionError("Resumption request requires a resumption token")
 


### PR DESCRIPTION
## Summary
- trim whitespace from SSE id before using as a resumption token

## Testing
- `pytest -n 0 tests/shared/test_streamable_http.py::test_streamablehttp_client_resumption -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bec922488332818fc3179a10bc79