### PR TITLE
Fix race in resumption test

### DIFF
--- a/tests/shared/test_streamable_http.py
+++ b/tests/shared/test_streamable_http.py
@@ -1156,6 +1156,12 @@ async def test_streamablehttp_client_resumption(event_server):
             assert result.content[0].type == "text"
             assert "Completed" in result.content[0].text
 
+            # Allow any pending notifications to be processed
+            for _ in range(50):
+                if captured_notifications:
+                    break
+                await anyio.sleep(0.1)
+
             # We should have received the remaining notifications
             assert len(captured_notifications) > 0
 


### PR DESCRIPTION
## Summary
- stabilize notification processing in resumption test

## Testing
- `pytest tests/shared/test_streamable_http.py::test_streamablehttp_client_resumption -vv -s -n auto`
- `pytest -n auto` *(fails: typer required)*

------
https://chatgpt.com/codex/tasks/task_e_685218b53b7883328eedd53bb4f053e2