### PR TITLE
refactor: unify OAuth providers and support basic auth

### DIFF
--- a/tests/server/fastmcp/auth/test_auth_integration.py
+++ b/tests/server/fastmcp/auth/test_auth_integration.py
@@ -1291,7 +1291,9 @@ class TestAuthorizeEndpointErrors:
         [{"grant_types": ["client_credentials"]}],
         indirect=True,
     )
-    async def test_client_credentials_token(self, test_client: httpx.AsyncClient, registered_client):
+    async def test_client_credentials_token(
+        self, test_client: httpx.AsyncClient, registered_client: dict[str, str]
+    ) -> None:
         response = await test_client.post(
             "/token",
             data={
@@ -1318,7 +1320,9 @@ class TestAuthorizeEndpointErrors:
         [{"grant_types": ["token_exchange"]}],
         indirect=True,
     )
-    async def test_token_exchange_success(self, test_client: httpx.AsyncClient, registered_client):
+    async def test_token_exchange_success(
+        self, test_client: httpx.AsyncClient, registered_client: dict[str, str]
+    ) -> None:
         response = await test_client.post(
             "/token",
             data={
@@ -1339,7 +1343,9 @@ class TestAuthorizeEndpointErrors:
         [{"grant_types": ["token_exchange"]}],
         indirect=True,
     )
-    async def test_token_exchange_invalid_subject(self, test_client: httpx.AsyncClient, registered_client):
+    async def test_token_exchange_invalid_subject(
+        self, test_client: httpx.AsyncClient, registered_client: dict[str, str]
+    ) -> None:
         response = await test_client.post(
             "/token",
             data={
@@ -1360,7 +1366,9 @@ class TestAuthorizeEndpointErrors:
         [{"grant_types": ["client_credentials", "token_exchange"]}],
         indirect=True,
     )
-    async def test_client_credentials_and_token_exchange(self, test_client: httpx.AsyncClient, registered_client):
+    async def test_client_credentials_and_token_exchange(
+        self, test_client: httpx.AsyncClient, registered_client: dict[str, str]
+    ) -> None:
         cc_response = await test_client.post(
             "/token",
             data={


### PR DESCRIPTION
## Summary
- extract common OAuth discovery and registration into `BaseOAuthProvider`
- handle `client_secret_basic` and `client_secret_post` credentials
- simplify token exchange and client credentials providers on shared base

## Testing
- `uv run --frozen ruff format .`
- `uv run --frozen ruff check .`
- `uv run --frozen pyright`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD="" uv run --frozen pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fb3784468832d912938701993b42d